### PR TITLE
[#131708701] Add deploy.sh, destroy.sh, and a Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.vagrant

--- a/README.md
+++ b/README.md
@@ -2,3 +2,22 @@ Usability Jenkins
 
 Vagrant configurations to make multiple EC2 VMs running Jenkins,
 for usability lab testing.
+
+# Usage:
+
+`PREFIX` is optional and defaults to `jenkins`.  It is used to name your vms,
+and to name the ssh key we generate.
+
+~~~
+PREFIX=example-jenkins ./deploy.sh
+~~~
+
+~~~
+PREFIX=example-jenkins ./destroy.sh
+~~~
+
+## Debugging
+
+~~~
+KEYFILE=.vagrant/usability-jenkins PREFIX=example-jenkins vagrant ssh jenkins.0
+~~~

--- a/README.md
+++ b/README.md
@@ -1,23 +1,57 @@
-Usability Jenkins
+# Usability Jenkins
 
-Vagrant configurations to make multiple EC2 VMs running Jenkins,
-for usability lab testing.
+Vagrant configurations to make multiple EC2 VMs running Jenkins, for usability lab testing.
 
-# Usage:
+## Laboratory
 
-`PREFIX` is optional and defaults to `jenkins`.  It is used to name your vms,
-and to name the ssh key we generate.
+Before the lab day, one of our colleague will need to run, the Jenkins deployment, using [`paas-usability-jenkins`](https://github.com/alphagov/paas-usability-jenkins) extension to `paas-cf`.
 
-~~~
-PREFIX=example-jenkins ./deploy.sh
-~~~
+The deployment should end up successfully, providing us with the credentials required for the Jenkins interface.
 
-~~~
-PREFIX=example-jenkins ./destroy.sh
-~~~
+These credentials should be passed onto the user, when their session approaches.
 
-## Debugging
+Each participant, will have the fresh Jenkins setup, allowing them to configure what's necessary, in order to deploy their applications with CloudFoundry.
 
-~~~
+At the end of the session, it will be safe to run the destroy functionality, which should release used resources.
+
+## How to
+
+The script makes use of some environment variables.
+
+ - `PREFIX` - Used for AWS resource names and key generators. Defaults to `jenkins`. This prefix, should be specified for both, `deploy` and `destroy` functionality. It does need to be the same.
+
+### deploy
+
+```
+./deploy.sh
+```
+
+#### Outcome
+
+```
+$ PREFIX=rafalp-jenkins ./deploy.sh
+
+Bringing machine 'jenkins.0' up with 'aws' provider...
+[...]
+==> jenkins.0: Jenkins instance available:
+==> jenkins.0:
+==> jenkins.0:   https://54.174.148.59/
+==> jenkins.0:   Username: user
+==> jenkins.0:   Password: qXmDjpn2HJ9C
+[...]
+To use this vm:
+  export KEYFILE=.vagrant/usability-jenkins
+  vagrant ssh
+```
+
+### destroy
+
+```
+./destroy.sh
+```
+
+### Debugging
+
+```
 KEYFILE=.vagrant/usability-jenkins PREFIX=example-jenkins vagrant ssh jenkins.0
-~~~
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,65 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.require_version ">= 1.8.0"
+
+if !ENV['KEYFILE']
+  puts "Need $KEYFILE"
+  exit 1
+end
+
+AWS_ACCOUNT = ENV.fetch("AWS_ACCOUNT", "dev")
+AWS_ACCOUNT_DATA = {
+  "dev" => {
+    :subnet_id => "subnet-2d54225b", # "usability-jenkins" 10.0.0.0/24 range
+    :security_group => "sg-a0639cc6", # "usability-jenkins" security group
+  },
+}
+AWS_ACCOUNT_VARIABLES = AWS_ACCOUNT_DATA.fetch(AWS_ACCOUNT)
+
+COUNT = 1
+
+Vagrant.configure(2) do |config|
+  Dir.glob("./post-deploy.d/*").sort.each do |post_deploy_file|
+    config.vm.provision "shell" do |s|
+      s.privileged = true
+      s.name = post_deploy_file
+      s.path = post_deploy_file
+    end
+  end
+
+  COUNT.times do |i|
+    config.vm.define "jenkins.#{i}" do |jenkins|
+      jenkins.vm.box = ENV['VAGRANT_BOX_NAME'] || 'aws_vagrant_box'
+
+      jenkins.vm.provider :aws do |aws, override|
+        aws.access_key_id = ENV['AWS_ACCESS_KEY_ID']
+        aws.secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
+        aws.associate_public_ip = true
+        aws.tags = { 'Name' => ENV['PREFIX'] + ".#{i}" }
+
+        # Jenkins marketplace ami from
+        #  https://aws.amazon.com/marketplace/pp/B00NNZUF3Q
+        #  https://aws.amazon.com/marketplace/fulfillment?productId=447af561-b7e2-4d03-8a67-4842db5439cb
+        aws.region = 'eu-west-1'
+        aws.ami = 'ami-99116dea'
+
+        aws.keypair_name = ENV['KEYNAME']
+        override.ssh.private_key_path = ENV['KEYFILE']
+        aws.instance_type = 'm3.medium'
+
+        aws.subnet_id = AWS_ACCOUNT_VARIABLES.fetch(:subnet_id)
+        aws.security_groups = [AWS_ACCOUNT_VARIABLES.fetch(:security_group)]
+
+        # Add IAM role to allow access to necessary AWS APIs
+        aws.iam_instance_profile_name = 'usability-jenkins'
+
+        # We will rely on vagrant generating a ssh key, but this must be the bitnami user, as the vagrant user does not exist on the vm
+        override.ssh.username = "bitnami"
+
+        # Fix issue on osx: https://github.com/mitchellh/vagrant/issues/5401#issuecomment-115240904
+        override.nfs.functional = false
+      end
+    end
+  end
+end

--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export PREFIX="${PREFIX:-jenkins}"
+export AWS_DEFAULT_REGION=eu-west-1
+
+export VAGRANT_DEFAULT_PROVIDER="aws"
+export VAGRANT_BOX_NAME="aws_vagrant_box"
+
+export KEYFILE=.vagrant/usability-jenkins
+export KEYNAME=${PREFIX}-key

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. common.sh
+
+# Install aws dummy box if not present
+if ! vagrant box list | grep -qe "^${VAGRANT_BOX_NAME} "; then
+  vagrant box add "${VAGRANT_BOX_NAME}" \
+    https://github.com/mitchellh/vagrant-aws/raw/74021d7c9fbc519307d661656f6ce96eeb61153c/dummy.box
+fi
+
+# Create and upload an ssh keypair if needed
+if [ ! -f "${KEYFILE}" ]; then
+  mkdir -p .vagrant
+  ssh-keygen -f "${KEYFILE}" -t rsa -b 4096 < /dev/null
+fi
+
+if ! aws ec2 describe-key-pairs --key-name "${KEYNAME}" > /dev/null 2>&1; then
+  aws ec2 import-key-pair \
+    --key-name "${KEYNAME}" \
+    --public-key-material "$(cat "${KEYFILE}.pub")"
+fi
+
+vagrant up
+
+cat << EOF
+To use this vm:
+  export KEYFILE=${KEYFILE}
+  vagrant ssh
+EOF

--- a/destroy.sh
+++ b/destroy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. common.sh
+
+if aws ec2 describe-key-pairs --key-name "${KEYNAME}" > /dev/null 2>&1; then
+  aws ec2 delete-key-pair --key-name "${KEYNAME}"
+fi
+
+vagrant destroy -f

--- a/post-deploy.d/00-extract-jenkins-password.sh
+++ b/post-deploy.d/00-extract-jenkins-password.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+PUBLIC_IP=$(curl -qs http://169.254.169.254/latest/meta-data/public-ipv4)
+PASSWORD=$(gawk "match(\$0, /application password to '(.*?)'/, array) { print array[1] }"  /var/log/boot.log)
+
+cat << EOF
+Jenkins instance available:
+
+  https://${PUBLIC_IP}/
+  Username: user
+  Password: ${PASSWORD}
+EOF

--- a/post-deploy.d/01-install-cf-cli.sh
+++ b/post-deploy.d/01-install-cf-cli.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+if [ ! -f /usr/bin/cf ]; then
+    wget -q "https://cli.run.pivotal.io/stable?release=debian64&version=6.22.1&source=github-rel" -O cf-cli.deb
+    dpkg -i ./cf-cli.deb && apt-get install -f
+fi


### PR DESCRIPTION
# What

[#131708701](https://www.pivotaltracker.com/n/projects/1275640/stories/131708701) Setup jenkins for user testing

Here we add a Vagarntfile and helper scripts to bring up EC2 instances running the bitnami Jenkins distribution.
# How to review

```
PREFIX=testing-jenkins ./deploy.sh
```

Check you can log into the jenkins uri with the credentials output during the run.

Check you can make an https request to the api -- depends on https://github.com/alphagov/paas-cf/pull/536 being deployed.

```
PREFIX=testing-jenkins vagrant ssh --  curl https://api.cloud.service.gov.uk
```

Clean up with

```
PREFIX=testing-jenkins ./destroy.sh
```
# Who can review

Not @richardc or @paroxp 
