### PR TITLE
Add certificate to approved list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ The script makes use of some environment variables.
 ./deploy.sh
 ```
 
+### certs
+
+This feature, should only need to be used in dev environment. Try to avoid the usage for other envs.
+
+```
+./certs.sh
+```
+
+**Note** This script, requires both, `DEPLOY_ENV` and `PREFIX` to be set.
+
 #### Outcome
 
 ```

--- a/certs.sh
+++ b/certs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+
+. common.sh
+
+aws s3 cp s3://${DEPLOY_ENV}-state/bosh-CA.tar.gz - | tar --to-stdout -xvzf - bosh-CA.crt | vagrant ssh jenkins.0 -- sudo /opt/bitnami/java/bin/keytool -noprompt -import -trustcacerts -alias ${DEPLOY_ENV}-boshCA-$(date +%s) -keystore /opt/bitnami/java/lib/security/cacerts -storepass changeit ; vagrant ssh jenkins.0 -- sudo /etc/init.d/bitnami restart


### PR DESCRIPTION
## What

In order for jenkins being able to connect with the CF API on our dev environment, we need to add the certificate used, to the approved list.

## How to review

  - Run the `deploy.sh` script and `certs.sh` afterwards. Both require the same `PREFIX` environment variable.
  - Attempt to run any `cf` command from Jenkins box.

## Who can review

Not @keymon, @paroxp
